### PR TITLE
Pricing is incorrectly transferred to Order where hierarchical Cart Items alter it

### DIFF
--- a/src/SpeckCheckoutOrder/Service/CheckoutService.php
+++ b/src/SpeckCheckoutOrder/Service/CheckoutService.php
@@ -76,7 +76,7 @@ class CheckoutService implements EventManagerAwareInterface
         $orderLine = new OrderLine();
         $orderLine->setOrder($order)
             ->setDescription($cartItem->getDescription())
-            ->setPrice($cartItem->getPrice())
+            ->setPrice($cartItem->getPrice(false, true))
             ->setTax($cartItem->getTax())
             ->setQuantityInvoiced($cartItem->getQuantity())
             ->setQuantityRefunded(0)


### PR DESCRIPTION
Small bugfix to ensure pricing altered by child cart items is correctly transferred into the order.